### PR TITLE
Fix alignments deduplicate

### DIFF
--- a/ccanalyser/cli/alignments_deduplicate.py
+++ b/ccanalyser/cli/alignments_deduplicate.py
@@ -65,9 +65,9 @@ def identify(
 
             # Extract chrom1 + start1 + chrom(last entry) + end(last entry)
             coords_df = df["coordinates"].str.extract(
-                r"^chr(?P<chrom1>[\d|X|Y|M]+):(?P<start>\d+).*\|chr(?P<chrom2>[\d|X|Y|M]+):\d+-(?P<end>\d+)"
+                r"^chr(?P<chrom1>.*?):(?P<start>\d+).*\|chr(?P<chrom2>.*?):\d+-(?P<end>\d+)"
             )
-
+            
             # {chrom1+start1+chrom-1+end-1(hashed): id(hashed)}
             coords_hashed = hash_column(
                 coords_df["chrom1"].str.cat(coords_df.iloc[:, 1:])

--- a/ccanalyser_conda_env.yml
+++ b/ccanalyser_conda_env.yml
@@ -17,6 +17,7 @@ dependencies:
   - ucsc-bedgraphtobigwig
   - nodejs
   - ucsc-fetchchromsizes
+  - ucsc-fatotwobit
   - samtools
   - numpy
   - natsort

--- a/environment.yml
+++ b/environment.yml
@@ -31,3 +31,4 @@ dependencies:
   - python-xxhash
   - trackhub
   - seaborn
+  - ucsc-fatotwobit


### PR DESCRIPTION
Extracting chromosome names in obscure formats e.g. chr14_GLXX_Random failed, resulting in NaN values attempting to be hashed. This caused a crash. Should now be fixed.
