### PR TITLE
Lower dedup memory

### DIFF
--- a/ccanalyser/cli/alignments_deduplicate.py
+++ b/ccanalyser/cli/alignments_deduplicate.py
@@ -121,7 +121,9 @@ def remove(
         os.unlink(output)
 
     df_slices = pd.read_csv(slices_fn, sep="\t", chunksize=buffer)
-    ids_duplicated = {int(x) for x in load_json(duplicated_ids)}
+
+    with xopen.xopen(duplicated_ids, 'r') as r:
+        ids_duplicated = {int(x) for x in ujson.load(r)}
 
     n_reads_total = 0
     n_reads_unique = 0

--- a/ccanalyser/cli/fastq_deduplicate.py
+++ b/ccanalyser/cli/fastq_deduplicate.py
@@ -18,6 +18,7 @@ from ccanalyser.tools.io import FastqReaderProcess, FastqWriterProcess
 from ccanalyser.tools.statistics import DeduplicationStatistics
 from ccanalyser.utils import invert_dict, load_json
 from xopen import xopen
+import tqdm
 
 def parse(input_files: Tuple, output: os.PathLike = "out.json", read_buffer: int = 1e5):
     """
@@ -82,18 +83,28 @@ def identify(input_files: Tuple, output: os.PathLike = "duplicates.json"):
     dedup_sequences = dict()
     read_ids = set()
 
-    np.random.shuffle(np.array(input_files))
-    for fn in input_files:
-        d = load_json(fn)  # {READ_NAME_HASH: SEQUENCE_HASH}
-        read_ids.update(d)
-        dedup_sequences.update(invert_dict(d))  # {SEQUENCE_HASH: READ_NAME_HASH}
+    
 
-    duplicated_ids = read_ids - set(dedup_sequences.values())
-    del read_ids
-    del dedup_sequences
+    input_files = np.array(input_files)
+    np.random.shuffle(input_files)
+
+    sequences_dedup = set() 
+    reads_duplicated = set()
+
+    for ii, fn in enumerate(tqdm.tqdm(input_files)): 
+        
+        fastq_hashed_dict = load_json(fn)
+        for name_hash, sequence_hash in fastq_hashed_dict.items():
+            
+            if not sequence_hash in sequences_dedup:
+                sequences_dedup.add(sequence_hash)
+            else:
+                reads_duplicated.add(name_hash)
+
+    del sequences_dedup
 
     with xopen(output, "w") as w:
-        duplicated_ids_dict = dict.fromkeys(duplicated_ids)
+        duplicated_ids_dict = dict.fromkeys(reads_duplicated)
         ujson.dump(duplicated_ids_dict, w)
 
 

--- a/ccanalyser/cli/fastq_deduplicate.py
+++ b/ccanalyser/cli/fastq_deduplicate.py
@@ -89,7 +89,7 @@ def identify(input_files: Tuple, output: os.PathLike = "duplicates.json"):
     np.random.shuffle(input_files)
 
     sequences_dedup = set() 
-    reads_duplicated = set()
+    reads_duplicated = list()
 
     for ii, fn in enumerate(tqdm.tqdm(input_files)): 
         
@@ -99,7 +99,7 @@ def identify(input_files: Tuple, output: os.PathLike = "duplicates.json"):
             if not sequence_hash in sequences_dedup:
                 sequences_dedup.add(sequence_hash)
             else:
-                reads_duplicated.add(name_hash)
+                reads_duplicated.append(name_hash)
 
     del sequences_dedup
 
@@ -140,7 +140,9 @@ def remove(
     
     """
 
-    duplicated_ids = set(load_json(duplicated_ids))
+    with xopen(duplicated_ids, 'r') as r:
+        duplicated_ids = {int(k) for k in ujson.load(r)}
+
     inputq = SimpleQueue()  # Reads are placed into this queue for deduplication
     writeq = SimpleQueue()  # Deduplicated reads are placed into the queue for writing
     statq = SimpleQueue()  # Statistics are sent on this queue for processing

--- a/ccanalyser/pipeline/pipeline.py
+++ b/ccanalyser/pipeline/pipeline.py
@@ -401,7 +401,7 @@ def fastq_duplicates_remove(infiles, outfile):
     dd_ids = (
         f"ccanalyser_preprocessing/deduplicated/deduplicated_ids/{sample_name}.json.gz"
     )
-    stats_prefix = f"ccanalyser_statistics/deduplication/data/{sample_name}_{sample_part}"
+    stats_prefix = f"ccanalyser_statistics/deduplication/data/{sample_name}{sample_part}"
     output_prefix = outfile.replace(".completed", "")
 
     if FASTQ_DEUPLICATE:
@@ -413,13 +413,13 @@ def fastq_duplicates_remove(infiles, outfile):
                                 --stats_prefix %(stats_prefix)s
                                 """
     else:
-        statement = """ln -s $(pwd)/%(fq1)s %(out1)s &&
-                       ln -s $(pwd)/%(fq2)s %(out2)s &&
+        statement = """ln -s $(pwd)/%(fq1)s %(output_prefix)s_1.fastq &&
+                       ln -s $(pwd)/%(fq2)s %(output_prefix)s_2.fastq &&
                        lc=$(cat %(fq1)s | wc -l);
                        logfile=%(stats_prefix)s.deduplication.csv;
                        echo "stat,stat_type,read_type,read_number,stage,sample" > $logfile;
                        echo -e $(($lc / 4)),reads_total,pe,0,deduplication,%(sample_name)s >> $logfile;
-                       echo -e $(($lc / 4)),reads_unique,pe,0,deduplication,%(sample_name)s >> $logfile
+                       echo -e $(($lc / 4)),reads_unique,pe,0,deduplication,%(sample_name)s >> $logfile;
                        echo -e 0,reads_removed,pe,0,deduplication,%(sample_name)s >> $logfile
                     """
 

--- a/ccanalyser/pipeline/pipeline.py
+++ b/ccanalyser/pipeline/pipeline.py
@@ -86,12 +86,12 @@ P.get_parameters("config.yml")
 N_SAMPLES = len(
     {re.match(r"(.*)_R*[12].fastq.*", fn).group(1) for fn in glob.glob("*.fastq*")}
 )
-
 # Has valid plotting coordinate bed file
 VALID_PLOT_COORDINATES = is_valid_bed(P.PARAMS.get("plot_coordinates"), verbose=False)
-
 # Create a UCSC hub or not
 MAKE_HUB = is_on(P.PARAMS.get("hub_create"))
+# Turns on FASTQ deduplication
+FASTQ_DEUPLICATE = P.PARAMS.get("deduplication_pre-dedup", False)
 
 
 ##############################
@@ -252,7 +252,7 @@ def fastq_qc(infile, outfile):
 
 
 @follows(mkdir("statistics"))
-@merge(fastq_qc, "statistics/fastqc_report.html")
+@merge(fastq_qc, "ccanalyser_statistics/fastqc_report.html")
 def fastq_multiqc(infile, outfile):
     """Collate fastqc reports into single report using multiqc"""
 
@@ -311,7 +311,8 @@ def fastq_split(infiles, outfile):
     touch_file(outfile)
 
 
-@active_if(P.PARAMS.get("deduplication_pre-dedup", False))
+
+@active_if(FASTQ_DEUPLICATE)
 @follows(
     mkdir("ccanalyser_preprocessing/deduplicated"),
     mkdir("ccanalyser_preprocessing/deduplicated/deduplicated_ids"),
@@ -331,7 +332,7 @@ def fastq_duplicates_parse(infiles, outfile, sample_name, part_no):
     Runs :ref:`ccanalyser fastq deduplicate parse <CLI Documentation>`
 
     """
-
+    
     fq1, fq2 = [os.path.abspath(fn) for fn in infiles]
 
     statement = """ccanalyser fastq deduplicate parse
@@ -345,7 +346,6 @@ def fastq_duplicates_parse(infiles, outfile, sample_name, part_no):
         job_memory="6G",
         job_condaenv=P.PARAMS["conda_env"],
     )
-
 
 @collate(
     fastq_duplicates_parse,
@@ -378,11 +378,10 @@ def fastq_duplicates_identify(infiles, outfile):
         zap_file(fn)
 
 
-@active_if(P.PARAMS.get("deduplication_pre-dedup", False))
 @follows(
     fastq_duplicates_parse,
     fastq_duplicates_identify,
-    mkdir("statistics/deduplication/data/"),
+    mkdir("ccanalyser_statistics/deduplication/data/"),
 )
 @collate(
     "ccanalyser_preprocessing/split/*.fastq*",
@@ -402,16 +401,27 @@ def fastq_duplicates_remove(infiles, outfile):
     dd_ids = (
         f"ccanalyser_preprocessing/deduplicated/deduplicated_ids/{sample_name}.json.gz"
     )
-    stats_prefix = f"statistics/deduplication/data/{sample_name}_{sample_part}"
+    stats_prefix = f"ccanalyser_statistics/deduplication/data/{sample_name}_{sample_part}"
     output_prefix = outfile.replace(".completed", "")
 
-    statement = """ccanalyser fastq deduplicate remove
-                            %(fq1)s %(fq2)s
-                            -d %(dd_ids)s
-                            -o %(output_prefix)s
-                            --sample_name %(sample_name)s
-                            --stats_prefix %(stats_prefix)s
-                            """
+    if FASTQ_DEUPLICATE:
+        statement = """ccanalyser fastq deduplicate remove
+                                %(fq1)s %(fq2)s
+                                -d %(dd_ids)s
+                                -o %(output_prefix)s
+                                --sample_name %(sample_name)s
+                                --stats_prefix %(stats_prefix)s
+                                """
+    else:
+        statement = """ln -s $(pwd)/%(fq1)s %(out1)s &&
+                       ln -s $(pwd)/%(fq2)s %(out2)s &&
+                       lc=$(cat %(fq1)s | wc -l);
+                       logfile=%(stats_prefix)s.deduplication.csv;
+                       echo "stat,stat_type,read_type,read_number,stage,sample" > $logfile;
+                       echo -e $(($lc / 4)),reads_total,pe,0,deduplication,%(sample_name)s >> $logfile;
+                       echo -e $(($lc / 4)),reads_unique,pe,0,deduplication,%(sample_name)s >> $logfile
+                       echo -e 0,reads_removed,pe,0,deduplication,%(sample_name)s >> $logfile
+                    """
 
     P.run(
         statement,
@@ -424,14 +434,15 @@ def fastq_duplicates_remove(infiles, outfile):
     touch_file(outfile)
 
     # Replace infiles with empty files
-    for fn in infiles:
-        zap_file(fn)
+    if FASTQ_DEUPLICATE:
+        for fn in infiles:
+            zap_file(fn)
 
 
 @follows(fastq_duplicates_remove)
 @merge(
-    "statistics/deduplication/data/*.csv",
-    "statistics/deduplication/deduplication.reads.csv",
+    "ccanalyser_statistics/deduplication/data/*.csv",
+    "ccanalyser_statistics/deduplication/deduplication.reads.csv",
 )
 def stats_deduplication_collate(infiles, outfile):
 
@@ -452,7 +463,7 @@ def stats_deduplication_collate(infiles, outfile):
 @follows(
     mkdir("ccanalyser_preprocessing/trimmed"),
     fastq_duplicates_remove,
-    mkdir("statistics/trimming/data/"),
+    mkdir("ccanalyser_statistics/trimming/data/"),
 )
 @collate(
     "ccanalyser_preprocessing/deduplicated/*.fastq*",
@@ -476,8 +487,8 @@ def fastq_trim(infiles, outfile):
                    -o %(outdir)s
                    %(fq1)s
                    %(fq2)s
-                   && mv ccanalyser_preprocessing/trimmed/%(fq1_basename)s_trimming_report.txt statistics/trimming/data
-                   && mv ccanalyser_preprocessing/trimmed/%(fq2_basename)s_trimming_report.txt statistics/trimming/data
+                   && mv ccanalyser_preprocessing/trimmed/%(fq1_basename)s_trimming_report.txt ccanalyser_statistics/trimming/data
+                   && mv ccanalyser_preprocessing/trimmed/%(fq2_basename)s_trimming_report.txt ccanalyser_statistics/trimming/data
                    """
     P.run(
         statement,
@@ -495,7 +506,7 @@ def fastq_trim(infiles, outfile):
 
 
 @follows(fastq_trim)
-@merge("statistics/trimming/data/*.txt", r"statistics/trimming/trimming.summary.csv")
+@merge("ccanalyser_statistics/trimming/data/*.txt", r"ccanalyser_statistics/trimming/trimming.summary.csv")
 def stats_trim_collate(infiles, outfile):
 
     """Extracts and collates adapter trimming statistics from trim_galore output"""
@@ -517,7 +528,7 @@ def stats_trim_collate(infiles, outfile):
         )
     )
 
-    df_trimming_stats.to_csv("statistics/trimming/trimming.summary.csv", index=False)
+    df_trimming_stats.to_csv("ccanalyser_statistics/trimming/trimming.summary.csv", index=False)
 
 
 @follows(fastq_trim, mkdir("ccanalyser_preprocessing/flashed"))
@@ -551,7 +562,7 @@ def fastq_flash(infiles, outfile):
 @follows(
     mkdir("ccanalyser_preprocessing/digested"),
     fastq_flash,
-    mkdir("statistics/digestion/data"),
+    mkdir("ccanalyser_statistics/digestion/data"),
 )
 @transform(
     "ccanalyser_preprocessing/flashed/*.fastq.gz",
@@ -576,7 +587,7 @@ def fastq_digest_combined(infile, outfile):
                    --minimum_slice_length 18
                    --compression_level %(pipeline_compression)s
                    -p 1
-                   --stats_prefix statistics/digestion/data/%(fn)s.flashed
+                   --stats_prefix ccanalyser_statistics/digestion/data/%(fn)s.flashed
                    --sample_name %(sn)s
                     """
     P.run(
@@ -589,7 +600,7 @@ def fastq_digest_combined(infile, outfile):
     zap_file(infile)
 
 
-@follows(fastq_flash, mkdir("statistics/digestion"))
+@follows(fastq_flash, mkdir("ccanalyser_statistics/digestion"))
 @collate(
     "ccanalyser_preprocessing/flashed/*.fastq.gz",
     regex(r"ccanalyser_preprocessing/flashed/(.*).notCombined_[12].fastq.gz"),
@@ -614,7 +625,7 @@ def fastq_digest_non_combined(infiles, outfile):
                    --minimum_slice_length 18
                    -p 1
                    --compression_level %(pipeline_compression)s
-                   --stats_prefix statistics/digestion/data/%(fn)s.pe
+                   --stats_prefix ccanalyser_statistics/digestion/data/%(fn)s.pe
                    --sample_name %(sn)s
                    """
 
@@ -630,7 +641,7 @@ def fastq_digest_non_combined(infiles, outfile):
 
 
 @follows(fastq_digest_combined, fastq_digest_non_combined)
-@merge("statistics/digestion/data/*", "statistics/digestion/digestion.reads.csv")
+@merge("ccanalyser_statistics/digestion/data/*", "ccanalyser_statistics/digestion/digestion.reads.csv")
 def stats_digestion_collate(infiles, outfile):
 
     """Aggregates in silico digestion statistics from fastq file partitions."""
@@ -921,7 +932,7 @@ def post_annotation():
     post_annotation,
     annotate_alignments,
     mkdir("ccanalyser_analysis/reporters/unfiltered/"),
-    mkdir("statistics/reporters/data"),
+    mkdir("ccanalyser_statistics/reporters/data"),
 )
 @transform(
     fastq_alignment,
@@ -941,7 +952,7 @@ def alignments_filter(infiles, outfile):
     output_prefix = outfile.replace(".completed", "")
     output_log_file = f"{output_prefix}.log"
     stats_prefix = (
-        f"statistics/reporters/data/{sample_name}_{sample_part}_{sample_read_type}"
+        f"ccanalyser_statistics/reporters/data/{sample_name}_{sample_part}_{sample_read_type}"
     )
 
     statement = """ccanalyser
@@ -1051,7 +1062,7 @@ def alignments_deduplicate_slices(
 
     slices, duplicated_ids = infile
     stats_prefix = (
-        f"statistics/reporters/data/{sample_name}_{read_type}_{capture_oligo}"
+        f"ccanalyser_statistics/reporters/data/{sample_name}_{read_type}_{capture_oligo}"
     )
 
     statement = """ccanalyser alignments deduplicate
@@ -1106,7 +1117,7 @@ def alignments_deduplicate_collate(infiles, outfile, *grouping_args):
 
 
 @follows(alignments_deduplicate_collate)
-@merge("statistics/reporters/data/*", "statistics/reporters/reporters.reads.csv")
+@merge("ccanalyser_statistics/reporters/data/*", "ccanalyser_statistics/reporters/reporters.reads.csv")
 def stats_alignment_filtering_collate(infiles, outfile):
 
     """'Combination of all reporter identification and filtering statistics"""
@@ -1323,7 +1334,7 @@ def reporters_store_merged(infiles, outfile, sample_name):
         stats_digestion_collate,
         stats_alignment_filtering_collate,
     ],
-    "statistics/run_statistics.csv",
+    "ccanalyser_statistics/run_statistics.csv",
 )
 def pipeline_merge_stats(infiles, outfile):
 
@@ -1341,7 +1352,7 @@ def pipeline_merge_stats(infiles, outfile):
 
 @merge(
     [pipeline_merge_stats],
-    "statistics/visualise_statistics.html",
+    "ccanalyser_statistics/visualise_statistics.html",
 )
 def pipeline_make_report(infile, outfile):
     """Run jupyter notebook for reporting and plotting pipeline statistics"""
@@ -1350,19 +1361,19 @@ def pipeline_make_report(infile, outfile):
     path_script_dir = os.path.dirname(path_script)
     path_nb_dir = os.path.dirname(path_script_dir)
 
-    statement_clean = "rm statistics/visualise_statistics* -f"
+    statement_clean = "rm ccanalyser_statistics/visualise_statistics* -f"
 
     statement_papermill = """papermill
                              -k python3
-                             -p directory $(pwd)/statistics/
+                             -p directory $(pwd)/ccanalyser_statistics/
                              %(path_nb_dir)s/visualise_statistics.ipynb
-                             statistics/visualise_statistics.ipynb
+                             ccanalyser_statistics/visualise_statistics.ipynb
                             """
     statement_nbconvert = """jupyter nbconvert
                              --no-input
                              --to html
-                             statistics/visualise_statistics.ipynb
-                             statistics/visualise_statistics.html
+                             ccanalyser_statistics/visualise_statistics.ipynb
+                             ccanalyser_statistics/visualise_statistics.html
                           """
 
     P.run(

--- a/ccanalyser/tests/test_deduplication.py
+++ b/ccanalyser/tests/test_deduplication.py
@@ -114,7 +114,6 @@ def test_fastq_removal():
     rdrp.join()
     rdrp.terminate()
 
-    breakpoint()
     # Correct number of duplicates removed
     assert len(result)  == len(test_data_dedup)
     

--- a/ccanalyser/tests/test_deduplication.py
+++ b/ccanalyser/tests/test_deduplication.py
@@ -27,7 +27,7 @@ test_data = [(PysamFakeEntry('1_1', 'AAAA', '\\\\'), PysamFakeEntry('1_2', 'TTTT
              (PysamFakeEntry('3_1', 'TTTT', '\\\\'), PysamFakeEntry('3_2', 'AAAA', '\\\\')),
             ]
 
-test_data_dedup = [(PysamFakeEntry('2_1', 'AAAA', '\\\\'), PysamFakeEntry('2_2', 'TTTT', '\\\\')),
+test_data_dedup = [(PysamFakeEntry('1_1', 'AAAA', '\\\\'), PysamFakeEntry('1_2', 'TTTT', '\\\\')),
                    (PysamFakeEntry('3_1', 'TTTT', '\\\\'), PysamFakeEntry('3_2', 'AAAA', '\\\\')),
             ]
 
@@ -97,7 +97,7 @@ def test_fastq_removal():
 
     with open(test_duplicates_path) as r:
         duplicates = ujson.load(r)
-        duplicates_set = set(duplicates)
+        duplicates_set = {int(k) for k in duplicates}
 
 
     rdrp = ReadDuplicateRemovalProcess(inq=inq, 
@@ -114,7 +114,7 @@ def test_fastq_removal():
     rdrp.join()
     rdrp.terminate()
 
-
+    breakpoint()
     # Correct number of duplicates removed
     assert len(result)  == len(test_data_dedup)
     

--- a/ccanalyser/tests/test_pipeline.py
+++ b/ccanalyser/tests/test_pipeline.py
@@ -88,7 +88,7 @@ def test_pipeline_all():
     completed = subprocess.run(cmd.split())
     
     assert completed.returncode == 0
-    assert os.path.exists('statistics/visualise_statistics.html')
+    assert os.path.exists('ccanalyser_statistics/visualise_statistics.html')
     assert len(glob.glob('ccanalyser_analysis/bigwigs/Slc25A37*.bigWig')) == 16
     assert os.path.exists('capturec_test.hub.txt')
 

--- a/ccanalyser/tools/deduplicate.py
+++ b/ccanalyser/tools/deduplicate.py
@@ -136,9 +136,7 @@ class ReadDuplicateRemovalProcess(Process):
 
                 hash_id = hash_function("".join([r.name for r in read_glob]))
 
-                # hash_id = "".join([r.name for r in read_glob])
-
-                if not str(hash_id) in duplicated_ids:
+                if not hash_id in duplicated_ids:
                     reads_unique.append(read_glob)
 
             self.outq.put(reads_unique)

--- a/ccanalyser/utils.py
+++ b/ccanalyser/utils.py
@@ -213,14 +213,16 @@ def intersect_bins(
     return df_intersect
 
 
-def load_json(fn) -> dict:
+def load_json(fn, dtype: str = "int") -> dict:
     """Convinence function to load gziped json file using xopen."""
 
     from xopen import xopen
 
     with xopen(fn) as r:
         d = ujson.load(r)
-        return d
+    
+    return {int(k): int(v) for k, v in d.items()}
+
 
 
 def get_timing(task_name=None) -> Callable:


### PR DESCRIPTION
Small changes to fastq deduplication to lower memory requirement. Large Tiled-C file (~8GB) can be processed in 9GB RAM, previously ~20GB followed by crash.